### PR TITLE
Update pod selector based on notification service used

### DIFF
--- a/stocktrader-operator/helm-charts/stocktrader/templates/notification-service.yaml
+++ b/stocktrader-operator/helm-charts/stocktrader/templates/notification-service.yaml
@@ -35,5 +35,10 @@ spec:
       port: 9443
       targetPort: 9443
   selector:
-    app: notification
+{{- if .Values.notificationSlack.enabled }}
+    app: notification-slack
+{{- end }}
+{{- if .Values.notificationTwitter.enabled }}
+    app: notification-twitter
+{{- end }}
 {{- end }}

--- a/stocktrader-operator/helm-charts/stocktrader/templates/portfolio.yaml
+++ b/stocktrader-operator/helm-charts/stocktrader/templates/portfolio.yaml
@@ -159,13 +159,13 @@ spec:
           - name: KAFKA_USER
             valueFrom:
               secretKeyRef:
-                name: {{ .Release.Name }}-kafka
+                name: {{ .Release.Name }}-credentials
                 key: kafka.user
                 optional: true
           - name: KAFKA_API_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ .Release.Name }}-kafka
+                name: {{ .Release.Name }}-credentials
                 key: kafka.apiKey
                 optional: true
           - name: JWT_AUDIENCE


### PR DESCRIPTION
Small fix so that notification-service directs to the correct pod based on the notification service used. Also syncs the portfolio yaml to point to the correct secret for Kafka Event Streams.