### PR TITLE
ActiveMQ URL support

### DIFF
--- a/bundle/manifests/operators.ibm.com_stocktraders.yaml
+++ b/bundle/manifests/operators.ibm.com_stocktraders.yaml
@@ -456,10 +456,20 @@ spec:
                     type: string
                 type: object
               mq:
-                description: IBM MQ settings (optional)
+                description: MQ settings (optional)
                 properties:
+                  kind:
+                    description: Kind of MQ Provider
+                    enum:
+                      - ibm-mq
+                      - amazon-mq-apache-mq
+                    type: string
                   channel:
                     description: Channel
+                    type: string
+                  url:
+                    description: >-
+                      Connection string with protocol(s) and port
                     type: string
                   host:
                     description: Host name (or IP address)

--- a/bundle/manifests/operators_v1_stocktrader.yaml
+++ b/bundle/manifests/operators_v1_stocktrader.yaml
@@ -187,6 +187,7 @@ spec:
   mq:
     kind: ibm-mq
     host: mqtrader1-mqtrader1
+    url: ssl://mqtrader-amazonaws.com:61617
     port: 1414
     id: app
     password: pwd

--- a/bundle/manifests/stocktrader-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/stocktrader-operator.clusterserviceversion.yaml
@@ -245,6 +245,7 @@ metadata:
             "mq": {
               "kind": "ibm-mq",
               "host": "mqtrader1-mqtrader1",
+              "url": "ssl://mqtrader-amazonaws.com:61617",
               "port": 1414,
               "id": "app",
               "password": "pwd",
@@ -1335,7 +1336,7 @@ spec:
 
           # Section for MQ settings
           - path: mq
-            displayName: IBM MQ settings
+            displayName: MQ settings
           - path: mq.kind
             description: This controls which JMS resource adapter (.rar file) gets loaded and how it is configured
             displayName: Select the appropriate MQ vendor for point-to-point messaging
@@ -1345,6 +1346,12 @@ spec:
           - path: mq.host
             description: Use the Kubernetes service DNS name if using an in-cluster MQ
             displayName: Host name (or IP address) for MQ
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:mq
+          - path: mq.url
+            description: Connection string for MQ
+            displayName: MQ connection string [ssl:// or failover://(ssl://..)]
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:text
               - urn:alm:descriptor:com.tectonic.ui:fieldGroup:mq

--- a/config/crd/bases/operators.ibm.com_stocktraders.yaml
+++ b/config/crd/bases/operators.ibm.com_stocktraders.yaml
@@ -456,13 +456,18 @@ spec:
                     type: string
                 type: object
               mq:
-                description: IBM MQ settings (optional)
+                description: MQ settings (optional)
                 properties:
                   channel:
                     description: Channel
                     type: string
+                  url:
+                    description: >-
+                      Connection string with protocol(s) and port
+                    type: string
                   host:
-                    description: Host name (or IP address)
+                    description: >-
+                      Host name, connection string, or IP address
                     type: string
                   id:
                     description: User ID

--- a/config/manifests/bases/stocktrader-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/stocktrader-operator.clusterserviceversion.yaml
@@ -245,6 +245,7 @@ metadata:
             "mq": {
               "kind": "ibm-mq",
               "host": "mqtrader1-mqtrader1",
+              "url": "ssl://mqtrader-amazonaws.com:61617",
               "port": 1414,
               "id": "app",
               "password": "pwd",
@@ -1335,7 +1336,7 @@ spec:
 
           # Section for MQ settings
           - path: mq
-            displayName: IBM MQ settings
+            displayName: MQ settings
           - path: mq.kind
             description: This controls which JMS resource adapter (.rar file) gets loaded and how it is configured
             displayName: Select the appropriate MQ vendor for point-to-point messaging
@@ -1345,6 +1346,12 @@ spec:
           - path: mq.host
             description: Use the Kubernetes service DNS name if using an in-cluster MQ
             displayName: Host name (or IP address) for MQ
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:mq
+          - path: mq.url
+            description: Connection string for MQ
+            displayName: MQ connection string [ssl:// or failover://(ssl://..)]
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:text
               - urn:alm:descriptor:com.tectonic.ui:fieldGroup:mq

--- a/config/samples/operators_v1_stocktrader.yaml
+++ b/config/samples/operators_v1_stocktrader.yaml
@@ -188,6 +188,7 @@ spec:
     kind: ibm-mq
     host: mqtrader1-mqtrader1
     port: 1414
+    url: ssl://mqtrader-amazonaws.com:61617
     id: app
     password: pwd
     queueManager: stocktrader

--- a/helm-charts/stocktrader/templates/account.yaml
+++ b/helm-charts/stocktrader/templates/account.yaml
@@ -146,6 +146,11 @@ spec:
               configMapKeyRef:
                 name: {{ tpl .Values.global.configMapName . }}
                 key: mq.kind
+          - name: MQ_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ tpl .Values.global.configMapName . }}
+                key: mq.url
           - name: MQ_HOST
             valueFrom:
               configMapKeyRef:

--- a/helm-charts/stocktrader/templates/config.yaml
+++ b/helm-charts/stocktrader/templates/config.yaml
@@ -46,6 +46,7 @@ data:
   database.db: {{ .Values.database.db }}
   database.ssl: "{{ .Values.database.ssl }}"
   mq.host: {{ .Values.mq.host }}
+  mq.url: {{ .Values.mq.url }}
   mq.kind: {{ .Values.mq.kind }}
   mq.port: "{{ .Values.mq.port }}"
   mq.queueManager: {{ .Values.mq.queueManager }}

--- a/helm-charts/stocktrader/templates/messaging.yaml
+++ b/helm-charts/stocktrader/templates/messaging.yaml
@@ -95,6 +95,11 @@ spec:
               configMapKeyRef:
                 name: {{ tpl .Values.global.configMapName . }}
                 key: mq.kind
+          - name: MQ_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ tpl .Values.global.configMapName . }}
+                key: mq.url
           - name: MQ_HOST
             valueFrom:
               configMapKeyRef:

--- a/helm-charts/stocktrader/values-metadata.yaml
+++ b/helm-charts/stocktrader/values-metadata.yaml
@@ -908,6 +908,11 @@ mq:
           value: "ibm-mq"
         - label: "Amazon MQ (Apache ActiveMQ)"
           value: "amazon-mq-apache-mq"
+  url:
+    __metadata:
+      label: "URL"
+      description: "Connection string with protocol(s) and port"
+      type: string
   host:
     __metadata:
       label: "Host"

--- a/helm-charts/stocktrader/values.yaml
+++ b/helm-charts/stocktrader/values.yaml
@@ -200,6 +200,7 @@ mq:
   kind: ibm-mq
   host: mqtrader1-mqtrader1
   port: 1414
+  url: ssl://mqtrader-amazonaws.com:61617
   id: app
   password: ""
   queueManager: stocktrader

--- a/old/deploy/crds/operators.ibm.com_stocktraders_crd.yaml
+++ b/old/deploy/crds/operators.ibm.com_stocktraders_crd.yaml
@@ -427,11 +427,16 @@ spec:
                   description: URL
                   type: string
             mq:
-              description: IBM MQ settings (optional)
+              description: MQ settings (optional)
               type: object
               properties:
+                url:
+                  description: >-
+                    Connection string with protocol(s) and port
+                  type: string
                 host:
-                  description: Host name (or IP address)
+                  description: >-
+                    Host name, connection string, or IP address
                   type: string
                 port:
                   description: Port number

--- a/old/deploy/crds/operators.ibm.com_v1_stocktrader_cr.yaml
+++ b/old/deploy/crds/operators.ibm.com_v1_stocktrader_cr.yaml
@@ -119,6 +119,7 @@ spec:
   mq:
     host: mqtrader1-mqtrader1
     port: 1414
+    url: ssl://mqtrader-amazonaws.com:61617
     id: app
     password: pwd
     queueManager: stocktrader

--- a/old/deploy/olm-catalog/stocktrader-operator/0.1.0/stocktrader-operator.v0.1.0.clusterserviceversion.yaml
+++ b/old/deploy/olm-catalog/stocktrader-operator/0.1.0/stocktrader-operator.v0.1.0.clusterserviceversion.yaml
@@ -165,6 +165,7 @@ metadata:
             "mq": {
               "host": "mqtrader1-mqtrader1",
               "port": 1414,
+              "url": "ssl://mqtrader-amazonaws.com:61617",
               "id": "app",
               "password": "pwd",
               "queueManager": "stocktrader",
@@ -752,6 +753,12 @@ spec:
           - path: mq.host
             description: Use the Kubernetes service DNS name if using an in-cluster MQ
             displayName: Host name (or IP address) for MQ
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:mq
+          - path: mq.url
+            description: Connection string for MQ
+            displayName: MQ connection string
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:text
               - urn:alm:descriptor:com.tectonic.ui:fieldGroup:mq

--- a/old/helm-charts/stocktrader/templates/account.yaml
+++ b/old/helm-charts/stocktrader/templates/account.yaml
@@ -60,6 +60,11 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}-config
                 key: mq.host
+          - name: MQ_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}-config
+                key: mq.url
           - name: MQ_PORT
             valueFrom:
               configMapKeyRef:

--- a/old/helm-charts/stocktrader/templates/config.yaml
+++ b/old/helm-charts/stocktrader/templates/config.yaml
@@ -41,6 +41,7 @@ data:
   database.port: "{{ .Values.database.port }}"
   database.db: {{ .Values.database.db }}
   mq.host: {{ .Values.mq.host }}
+  mq.url: "{{ .Values.mq.url }}"
   mq.port: "{{ .Values.mq.port }}"
   mq.queueManager: {{ .Values.mq.queueManager }}
   mq.queue: {{ .Values.mq.queue }}

--- a/old/helm-charts/stocktrader/templates/messaging.yaml
+++ b/old/helm-charts/stocktrader/templates/messaging.yaml
@@ -56,6 +56,11 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}-config
                 key: mq.host
+          - name: MQ_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}-config
+                key: mq.url
           - name: MQ_PORT
             valueFrom:
               configMapKeyRef:

--- a/old/helm-charts/stocktrader/values-metadata.yaml
+++ b/old/helm-charts/stocktrader/values-metadata.yaml
@@ -518,12 +518,17 @@ odm:
       type: string
 mq:
   __metadata:
-    label: "IBM MQ settings (optional)"
+    label: "MQ settings (optional)"
     description: "Configuration for MQ.  Can be in-cluster, or external.  Needed only if you want to receive notifications about changes in loyalty level"
+  url:
+    __metadata:
+      label: "URL"
+      description: "Connection string with protocol(s) and port"
+      type: string
   host:
     __metadata:
       label: "Host"
-      description: "Host name, or IP address, for MQ.  Use the Kube DNS service name if using an intra-cluster deployment of MQ"
+      description: "Host name, connection string, or IP address"
       type: string
   port:
     __metadata:

--- a/old/helm-charts/stocktrader/values.yaml
+++ b/old/helm-charts/stocktrader/values.yaml
@@ -123,6 +123,7 @@ odm:
 mq:
   host: mqtrader1-mqtrader1
   port: 1414
+  url: ssl://mqtrader-amazonaws.com:61617
   id: app
   password: ""
   queueManager: stocktrader


### PR DESCRIPTION
This PR adds the ability to specify an Apache ActiveMQ URL as the connection to the MQ provider.  This includes the `failover:` protocol for ActiveMQ highly available brokers.

There are two additional PRs for the two microservices which make use of JMS over MQ to use this new capability.
* [`account`](https://github.com/IBMStockTrader/account/pull/6)
* [`messaging`](https://github.com/IBMStockTrader/messaging/pull/13)