### PR TITLE
HPA v2 updates to Broker, Portfolio,  Account,  CashAccount, and StockQuote

### DIFF
--- a/helm-charts/stocktrader/templates/account.yaml
+++ b/helm-charts/stocktrader/templates/account.yaml
@@ -313,7 +313,7 @@ spec:
 {{- if .Values.account.autoscale }}
 ---
 #Deploy the autoscaler
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-account-hpa
@@ -341,7 +341,14 @@ spec:
     name: {{ .Release.Name }}-account
   minReplicas: {{ .Values.account.replicas }}
   maxReplicas: {{ .Values.account.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.account.cpuThreshold }}
+  # Replace legacy targetCPUUtilizationPercentage with proper v2 metrics
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.account.cpuThreshold }}
 {{- end }}
 ---
 #Deploy the service

--- a/helm-charts/stocktrader/templates/broker.yaml
+++ b/helm-charts/stocktrader/templates/broker.yaml
@@ -223,7 +223,7 @@ spec:
 {{- if .Values.broker.autoscale }}
 ---
 #Deploy the autoscaler
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-broker-hpa
@@ -251,7 +251,14 @@ spec:
     name: {{ .Release.Name }}-broker
   minReplicas: {{ .Values.broker.replicas }}
   maxReplicas: {{ .Values.broker.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.broker.cpuThreshold }}
+  # Replace legacy targetCPUUtilizationPercentage with proper v2 metrics
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.broker.cpuThreshold }}
 {{- end }}
 ---
 #Deploy the service

--- a/helm-charts/stocktrader/templates/cash-account.yaml
+++ b/helm-charts/stocktrader/templates/cash-account.yaml
@@ -233,7 +233,7 @@ spec:
 {{- if .Values.cashAccount.autoscale }}
 ---
 #Deploy the autoscaler
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-cash-account-hpa
@@ -261,7 +261,14 @@ spec:
     name: {{ .Release.Name }}-cash-account
   minReplicas: {{ .Values.cashAccount.replicas }}
   maxReplicas: {{ .Values.cashAccount.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.cashAccount.cpuThreshold }}
+  # Replace legacy targetCPUUtilizationPercentage with proper v2 metrics
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.cashAccount.cpuThreshold }}
 {{- end }}
 ---
 #Deploy the service

--- a/helm-charts/stocktrader/templates/portfolio.yaml
+++ b/helm-charts/stocktrader/templates/portfolio.yaml
@@ -249,7 +249,7 @@ spec:
 {{- if .Values.portfolio.autoscale }}
 ---
 #Deploy the autoscaler
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-portfolio-hpa
@@ -277,7 +277,14 @@ spec:
     name: {{ .Release.Name }}-portfolio
   minReplicas: {{ .Values.portfolio.replicas }}
   maxReplicas: {{ .Values.portfolio.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.portfolio.cpuThreshold }}
+  # Replace legacy targetCPUUtilizationPercentage with proper v2 metrics
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.portfolio.cpuThreshold }}
 {{- end }}
 ---
 #Deploy the service

--- a/helm-charts/stocktrader/templates/stock-quote.yaml
+++ b/helm-charts/stocktrader/templates/stock-quote.yaml
@@ -211,7 +211,7 @@ spec:
 {{- if .Values.stockQuote.autoscale }}
 ---
 #Deploy the autoscaler
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-stock-quote-hpa
@@ -239,7 +239,14 @@ spec:
     name: {{ .Release.Name }}-stock-quote
   minReplicas: {{ .Values.stockQuote.replicas }}
   maxReplicas: {{ .Values.stockQuote.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.stockQuote.cpuThreshold }}
+  # Replace legacy targetCPUUtilizationPercentage with proper v2 metrics
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.stockQuote.cpuThreshold }}
 {{- end }}
 ---
 #Deploy the service


### PR DESCRIPTION
Hi John, Anand,
I’ve updated the Horizontal Pod Autoscaler (HPA) implementation across the following services to align with autoscaling/v2 API specifications:
Broker
Portfolio
Account
CashAccount
StockQuote

The changes include replacing the legacy targetCPUUtilizationPercentage with the v2 metrics structure (metrics.resource.target.averageUtilization), ensuring consistency and compatibility with the current Kubernetes HPA schema.

@Anand — please test these commits and validate the autoscaling behavior.
@John — once testing is complete and verified, you can proceed with merging the changes.

Thanks,
Venkat