### PR TITLE
Add Conditional Multi-AZ Topology Spread Constraints for Trader Microservice

### DIFF
--- a/helm-charts/stocktrader/templates/trader.yaml
+++ b/helm-charts/stocktrader/templates/trader.yaml
@@ -62,19 +62,20 @@ spec:
       - name: {{ tpl .Values.global.pullSecretName . }}
 {{- end }}
       topologySpreadConstraints:
+      {{- if .Values.trader.topologySpread.multiAzEnabled }}
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
               app: trader
+      {{- end }}
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: trader
-
       containers:
       - name: trader
         image: "{{ .Values.trader.image.repository }}:{{ .Values.trader.image.tag }}"

--- a/helm-charts/stocktrader/values.yaml
+++ b/helm-charts/stocktrader/values.yaml
@@ -119,6 +119,9 @@ trader:
   autoscale: false
   maxReplicas: 10
   cpuThreshold: 75
+  # NEW: multi-AZ toggle for topology spread
+  topologySpread:
+    multiAzEnabled: true   # set to false for single-AZ clusters
   image:
     repository: ghcr.io/ibmstocktrader/trader
     tag: 1.0.0


### PR DESCRIPTION
This PR introduces optional Multi-AZ topology spread constraints for the Trader microservice.
A new flag trader.topologySpread.multiAzEnabled is added in values.yaml to control whether zone-level spreading is enforced.

Key Changes
- Added topologySpread configuration under .Values.trader.
- Applied zone-level topology spread (topology.kubernetes.io/zone) only when multiAzEnabled=true.
- Always apply node-level topology spread (kubernetes.io/hostname) to retain HA within the AZ.
Prevents pods from remaining Pending on single-AZ clusters by disabling the zone constraint when not applicable.

<img width="841" height="169" alt="image" src="https://github.com/user-attachments/assets/b9e7e095-7115-470f-b0f2-1e362fb6cb98" />

This allows the chart to work seamlessly for both production-grade Multi-AZ EKS clusters and lightweight single-AZ test clusters.